### PR TITLE
HotFix/Update getter for the case in which no student projects exist for a mod

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,12 +21,6 @@ export default new Vuex.Store({
     },
     setAllModules (state, singleModule) {
       state.allModules.push(singleModule)
-    },
-    setSelectedModule (state, selectedModule) {
-      state.selectedModule = selectedModule
-    },
-    setSelectedProject (state, selectedProject) {
-      state.selectedProject = selectedProject
     }
     // setNotes (state, notes) {
     //   state.selectedProject.studentNotes.unshift(notes)
@@ -79,8 +73,11 @@ export default new Vuex.Store({
   getters: {
     getSelectedProject: (state) => (selectedModuleNum, selectedProjectNum) => {
       const foundModule = state.allModules.find(dataSet => Number(dataSet.data.attributes.mod) === selectedModuleNum)
-      const foundProject = foundModule.data.attributes.student_projects.find(dataSet => Number(dataSet.project_number) === selectedProjectNum)
-      return foundProject
+      if (foundModule.data.attributes.student_projects) {
+        return foundModule.data.attributes.student_projects.find(dataSet => Number(dataSet.project_number) === selectedProjectNum)
+      } else {
+        return undefined
+      }
     }
     // getCurrentModule
     // getAllModules


### PR DESCRIPTION
### What does this PR do?
* Prior iterations did not account for the case in which a student has no projects at all for a given mod. In this case, the data we would get back from a fetch request was a null value, so we could not match the project selected with anything in the data. This prevented anything from being returned for the getter, and so wherever the getter was being called in the HTML, we were getting an un-rendered component (aka a blank screen).

* This hotfix adjusts the getter to account for this possibility.

### Anything specific the reviewer should look at?
* Just click on all the modules and projects and check the UI for appropriate messages.

Closes # NA
