### PR TITLE
Only set studentNotes if student_comments is not null

### DIFF
--- a/src/components/StudentFeedback.vue
+++ b/src/components/StudentFeedback.vue
@@ -106,12 +106,8 @@ export default {
     }
   },
   created () {
-    if (this.project) {
+    if (this.project.student_comments !== null) {
       this.studentNotes = this.project.student_comments
-    }
-
-    if (this.project.student_comments === null) {
-      this.studentNotes.push('')
     }
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,10 +15,10 @@ export default new Vuex.Store({
     loggedIn: true,
     authenticated: true,
     instructorAuth: false,
-    userId: 94,
-    userName: 'Lesha'
-    // userId: 1,
-    // userName: 'Olive'
+    // userId: 94,
+    // userName: 'Lesha'
+    userId: 1,
+    userName: 'Olive'
     // instructorAuth: true,
     // userId: 112,
     // userName: 'Daniele'


### PR DESCRIPTION
### What does this PR do?
* Fixes the bug where a new student note (when none existed for that project previously) updates in the UI and gets sent to the back end as an array and is updated accordingly.
* I'm also changing our user to the FE 2011 student so we can see more than one module.

### Anything specific the reviewer should look at?
* test it in the UI. I'll erase comments in the current student's projects.

Closes #
